### PR TITLE
Redact local Windows username/paths in RC2 workspace docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ dist_rc_validation/
 
 # VM gate, handoff snapshots, runtime data
 .vm_gate/
+.project_archive/
 handoff_output/
 logs/
 *.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+# GameArchiveManager agent policy
+
+These instructions apply to the entire repository.
+
+## Canonical workspace
+
+- Use `C:\Users\<redacted>\Documents\GameArchiveManager` as the only project entry. It is a junction to this Git working tree.
+- Read `START_HERE.md` before doing any project work. It is the agent-neutral continuation entry and records the current handoff state and next action.
+- Do not create or resume another GameArchiveManager clone, worktree, agent workspace, or version-suffixed copy unless the user explicitly requests one.
+- Historical Grok, Codex, Antigravity, evidence, and legacy-copy material is centralized under `.project_archive/`. Treat it as read-only reference material, not as an active checkout.
+- Keep new product code, tests, and authoritative documentation in this main working tree. Put local VM evidence in `.vm_gate/` and handoff snapshots in `handoff_output/` rather than creating another project directory.
+- Read `docs/WORKSPACE_MAP.md` when locating historical material.
+
+## Coordination
+
+- Inspect `git status --short` before editing and preserve unrelated user or agent changes.
+- Never allow two agents to edit the same files concurrently. Assign non-overlapping ownership if the user explicitly asks for parallel agent work.
+- Handoffs must name the canonical path, changed files, verification commands, and unresolved risks. Do not refer another agent to an archived checkout as its working directory.
+- Do not move material back out of `.project_archive/` to recreate an old workspace. Copy only the specific information that is intentionally being promoted into the main project.
+
+## Project safety gates
+
+- Do not push, merge, rebase, reset, clean, tag, publish a release, upload artifacts, or modify repository settings without the user's clear authorization for that action.
+- Do not overwrite or delete source archives, weaken CRC/SHA-256/path-boundary checks, persist plaintext passwords, or treat skipped tests as clean-VM evidence.
+- Keep the application identified as `0.1.0 Release Candidate` until the authoritative release gates are genuinely closed and the user approves a formal release.
+- Before release-related changes, read `project_state.json`, `docs/CURRENT_STATUS.md`, `docs/KNOWN_ISSUES.md`, and `docs/RC_SMOKE_TEST.md`.
+- For code changes, run relevant focused tests and then the full suite: `py -B -m unittest discover -s tests -p "test_*.py" -v`.

--- a/GROK_INITIAL_PROMPT.md
+++ b/GROK_INITIAL_PROMPT.md
@@ -1,19 +1,21 @@
 # 可直接复制给 Grok Build 的第一条指令
 
+> 历史模板：新接手统一使用 `START_HERE.md`，不要直接按下方旧基线执行。
+
 我已上传 `GameArchiveManager 0.1.0 RC` 自包含交接包。请你正式接管这个项目。
 
 严格执行以下要求：
 
-1. 首先完整阅读根目录 `GROK_START_HERE.md`，它是本次跨 AI 接管入口。
+1. 首先完整阅读根目录 `START_HERE.md`，它是统一跨 AI 接管入口；`GROK_START_HERE.md` 仅为历史专项补充。
 2. 然后按其中的 Agent Startup Protocol 阅读 `project_state.json` 与指定治理文档。
 3. 在修改任何文件前，运行并报告：
    - `py -B -m unittest discover -s tests -v`
    - `py scripts/verify_project_state.py`
    - `py scripts/rc_readiness.py`
-4. 当前权威基线是：0.1.0 / Release Candidate、Feature Freeze、测试最低 224、P0 为空、真实样本 1–6 已记录 PASS、Clean Windows 11 VM 仍为 false、RC 当前应为 NO-GO。
+4. 当前权威基线是：0.1.0 / Release Candidate、Feature Freeze、测试最低 224（已核验 234）、P0 为空、真实样本 1–6 已记录 PASS、Clean Windows 11 VM 已为 true、RC readiness 应为 GO；这不自动授权正式发布。
 5. 不得把外部工具测试 skip 当成真实验证通过，不得把宿主机或 Linux 测试当成干净 Windows 11 VM 证据。
 6. 不得新增功能。冻结核心只有在真实 VM 测试证明存在明确、可复现 bug 后，才能按 `DEBUGGING_PROTOCOL.md` 单独评估是否修改。
 7. 不自动下载/安装工具，不删除或覆盖用户文件，不记录密码，不擅自把 RC 标成正式 Release。
 8. 首次回复只做“接管一致性检查”：列出读取内容、命令结果、基线差异、Release Gate 和下一步；在我确认前不要修改业务代码。
 
-接管检查通过后，继续当前唯一主线：按照 `docs/RC_SMOKE_TEST.md` 完成 Clean Windows 11 VM 最终门禁并保存可审计证据。不要重复已经完成且有证据的工作。
+接管检查通过后，继续当前唯一主线：完成 `docs/RELEASE_CHECKLIST.md` 剩余人工检查并提交仓库所有者 Go/No-Go 评审。不要重复已经完成且有证据的 Win11 VM 工作。

--- a/GROK_START_HERE.md
+++ b/GROK_START_HERE.md
@@ -1,5 +1,7 @@
 # GameArchiveManager — Grok Build 接管入口
 
+> 此文件保留为历史 Grok 专项说明。所有新接手者（人工、Codex、Grok、Antigravity 或其他 agent）统一先读根目录 [`START_HERE.md`](START_HERE.md)，并只使用其中指定的唯一工作区。
+
 > 本文件是 Grok Build 接管本项目时的第一阅读入口。不要依赖聊天记录推断项目状态。
 
 ## 1. 当前权威状态
@@ -12,8 +14,8 @@
 - 本次交接前验证：234 tests / OK（skipped=7）
 - 项目治理校验：PASS
 - 真实样本 Test Game 1–6：项目状态记录为 PASS
-- Clean Windows 11 VM：`NOT VERIFIED`（`clean_windows_11_vm=false`；旧 RC1 的通过记录不适用于安全加固后的 RC2）
-- 当前发布结论：RC2 已按仓库所有者确认公开并标记 GitHub Latest，但仍是 0.1.0 Release Candidate；在 Win11 门禁通过前，`rc_readiness.py` 保持 **NO-GO**，Latest 不等于稳定版验证通过
+- Clean Windows 11 VM：`PASS`（当前 RC2 ZIP `BA3A9ADD…` / EXE `67DF840B…`；`clean_windows_11_vm=true`）
+- 当前发布结论：`rc_readiness.py` 预期 **GO**，表示 RC 门禁具备最终评审条件；仍是 0.1.0 Release Candidate，Latest 和 GO 都不等于已授权稳定版发布
 - Windows 10 VM：可选，未验证
 
 `version.py` 是应用版本信息的唯一代码权威来源；`project_state.json` 是项目状态、测试基线和 Release Gate 的机器可读权威来源。不要把 RC 改成正式 Release，也不要把尚未完成的 VM 检查标成通过。
@@ -48,17 +50,7 @@ py scripts/rc_readiness.py
 
 干净 Windows 11 VM 冒烟已按 `docs/RC_SMOKE_TEST.md` 关闭门禁。当前仍不是新增功能阶段；不要把 RC 改成正式 Release，除非用户明确要求并完成发布清单。
 
-Win11 已关闭门禁的证据摘要（详见 `GrokWork\projects\GameArchiveManager\data\vm_gate_20260823.md`）：
-
-- 已在独立 VirtualBox Windows 11 虚拟机启动 RC EXE，VM 中没有可用 Python 开发环境。
-- EXE 能启动并显示 `0.1.0 / Release Candidate`。
-- 无外部工具时不会崩溃；ZIP 执行返回结构化 `TOOL_NOT_FOUND`。
-- 两次可比冷启动到菜单约 3.07 秒和 3.06 秒。
-- 单独复制 7-Zip 26.02 的 `7z.exe` 不构成有效工具部署；该版本还需要同目录 `7z.dll`。这属于测试工具准备问题，不是已证明的业务代码缺陷。
-- VirtualBox 共享剪贴板不稳定；曾使用只读虚拟光盘和键盘扫描码完成操作。
-- VM 会偶发停在 `Stopping`，此前在确认 Guest 已进入 OFF/DESTROYING 后才强制结束卡住的 `VirtualBoxVM` 进程。
-
-上述项已在干净 Win11 Guest 上留下可审计记录。`clean_windows_11_vm` 已 true。Windows 10 可选未测。
+当前证据以根目录 `rc2_smoke_codex.md`、`rc2_item14_codex.md`、`rc2_vm_status.md` 和 `.vm_gate/` 为准。历史 Grok VM 记录已经集中到 `.project_archive/agents/grok/`，只作追溯，不替代当前 RC2 证据。Windows 10 可选未测。
 
 ## 4. Feature Freeze 与禁止事项
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,14 @@
 
 [![CI](https://github.com/HypnosysNyx/GameArchiveManager/actions/workflows/ci.yml/badge.svg)](https://github.com/HypnosysNyx/GameArchiveManager/actions/workflows/ci.yml) [![CodeQL](https://github.com/HypnosysNyx/GameArchiveManager/actions/workflows/codeql.yml/badge.svg)](https://github.com/HypnosysNyx/GameArchiveManager/actions/workflows/codeql.yml) [![Latest release](https://img.shields.io/github/v/release/HypnosysNyx/GameArchiveManager)](https://github.com/HypnosysNyx/GameArchiveManager/releases/latest) [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
+Maintainers and AI agents: start with [`START_HERE.md`](START_HERE.md). Use the single canonical workspace documented there.
+
 Windows CLI tool for messy **game download archives**: it looks at real file headers (not the extension), unpacks nested wrappers, tries a limited set of passwords, and copies the actual game (or generic content) to a safe output folder.
 
 It is not a save-file manager, not a GUI, and not a replacement for 7-Zip. You still install 7-Zip; this program decides *what* to unpack and *what* to keep.
 
 **Current version: 0.1.0 RC2 (Release Candidate)** — not a stable release.  
-Automated tests and the Windows build smoke test passed. Clean Windows 10/11 VM revalidation for RC2 is still pending.
+Automated tests and the clean Windows 11 VM smoke test passed. Windows 10 remains optional and untested.
 
 **[Download this program](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.zip)** · [SHA-256 checksums](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.sha256) · [中文说明](#gamearchivemanager-中文)
 
@@ -115,7 +117,7 @@ Or `start_game_archive_manager.bat`. Same CLI as the EXE. Tests: `py -B -m unitt
 
 Source is [MIT](LICENSE). 7-Zip, WinRAR, and LZ4 stay under their own licenses. The official LZ4 CLI is GPL-2.0-or-later; this repo does not ship `lz4.exe`.
 
-More docs: [`docs/USER_GUIDE.md`](docs/USER_GUIDE.md) · [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md) · [`docs/SECURITY.md`](docs/SECURITY.md) · [`security audit`](docs/SECURITY_AUDIT_2026-08-24.md) · [`docs/CURRENT_STATUS.md`](docs/CURRENT_STATUS.md) · [`docs/KNOWN_ISSUES.md`](docs/KNOWN_ISSUES.md)
+More docs: [`docs/USER_GUIDE.md`](docs/USER_GUIDE.md) · [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md) · [`docs/SECURITY.md`](docs/SECURITY.md) · [`security audit`](docs/SECURITY_AUDIT_2026-08-24.md) · [`release audit`](docs/RELEASE_AUDIT_2026-08-28.md) · [`docs/CURRENT_STATUS.md`](docs/CURRENT_STATUS.md) · [`docs/KNOWN_ISSUES.md`](docs/KNOWN_ISSUES.md)
 
 Project policies: [`SECURITY.md`](SECURITY.md) · [`CONTRIBUTING.md`](CONTRIBUTING.md) · [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
 
@@ -128,7 +130,7 @@ Project policies: [`SECURITY.md`](SECURITY.md) · [`CONTRIBUTING.md`](CONTRIBUTI
 它**不是**游戏存档管理器，**没有**图形界面，也**不能代替** 7-Zip。请先自己安装 7-Zip；本程序负责判断解什么、留下什么。
 
 **当前版本：0.1.0 RC2 Release Candidate（候选版，不是正式版）。**  
-自动化测试和 Windows 构建冒烟测试已通过；RC2 的干净 Windows 10/11 虚拟机复验仍待完成。
+自动化测试和干净 Windows 11 虚拟机冒烟测试已通过；Windows 10 仍为可选未测试项。
 
 **[下载本程序](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.zip)** · [SHA-256 校验文件](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.sha256)
 

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -1,0 +1,88 @@
+# GameArchiveManager 统一接管入口
+
+本文件面向任何后续维护者或 AI agent，不依赖旧聊天记录。最后核对：2026-08-28（Asia/Shanghai）。
+
+## 1. 只打开这个目录
+
+```text
+C:\Users\<redacted>\Documents\GameArchiveManager
+```
+
+它是固定入口，指向当前 Git 主工作树 `GameArchiveManager0.1.0`。不要去 GrokWork、Documents\Codex、旧副本或 `.project_archive` 中继续开发。历史材料的位置见 [`docs/WORKSPACE_MAP.md`](docs/WORKSPACE_MAP.md)。
+
+## 2. 五分钟接管检查
+
+先执行只读检查：
+
+```powershell
+git status --short --branch
+py -B scripts/verify_project_state.py
+py -B scripts/rc_readiness.py
+```
+
+然后按顺序阅读：
+
+1. 本文件；
+2. [`project_state.json`](project_state.json)；
+3. [`docs/CURRENT_STATUS.md`](docs/CURRENT_STATUS.md)；
+4. [`docs/KNOWN_ISSUES.md`](docs/KNOWN_ISSUES.md)；
+5. [`docs/RC_SMOKE_TEST.md`](docs/RC_SMOKE_TEST.md)；
+6. 需要理解架构时再读 [`docs/PROJECT_HANDOFF.md`](docs/PROJECT_HANDOFF.md) 和 [`docs/DEBUGGING_PROTOCOL.md`](docs/DEBUGGING_PROTOCOL.md)。
+
+如果代码、Git 状态、机器状态文件和叙述文档冲突，不要猜测，也不要自动采用日期最新的文件。先核对原始测试或 VM 证据，并把冲突标成 `NEEDS_VERIFICATION`。
+
+## 3. 当前真实状态
+
+- 产品：GameArchiveManager `0.1.0 RC2`，仍是 Release Candidate，不是正式稳定版。
+- Git 基线：`main` 的已提交 HEAD 为 `85a95bc`；远端发布动作不属于默认授权范围。
+- 自动化测试：2026-08-28 实跑 `234 tests — OK`。
+- 项目治理验证：2026-08-28 实跑 `Overall: PASS`。
+- `project_state.json` 已在 2026-08-28 归并证据后将 `clean_windows_11_vm=true`；`scripts/rc_readiness.py` 的预期结果为 `GO`。
+- 真实样本回归、密码泄漏检查和源文件完整性策略均已通过现有治理检查。
+- Windows 10 VM 是可选未验证项；不得谎报为 PASS。
+
+## 4. 当前唯一工作主线
+
+RC2 的干净 Windows 11 必选门禁已经归并并关闭：
+
+1. [`rc2_smoke_codex.md`](rc2_smoke_codex.md) 覆盖清单 1–13、15–17；其中原始 `BLOCKED` 是清单 14 尚未补做时的阶段性结论。
+2. [`rc2_item14_codex.md`](rc2_item14_codex.md) 已用宿主机 GUI 扫描码完成 EXTRACTING、SCANNING、VALIDATING 三阶段真实 Ctrl+C，源哈希未变，中断后重跑成功。
+3. [`rc2_vm_status.md`](rc2_vm_status.md) 记录任务结束和来宾正常关机；VirtualBox GUI 外壳只在日志已经记录 VM `OFF` 后才经用户批准清理。
+4. 被测原始 ZIP `BA3A9ADD…` 保持不变；其内附带旧 Markdown 写错 EXE 哈希，源码权威文档已明确实际 EXE 为 `67DF840B…`。不得声称原 ZIP 内文档已经被修改。
+
+下一步以 [`docs/RELEASE_AUDIT_2026-08-28.md`](docs/RELEASE_AUDIT_2026-08-28.md) 为准：本地归并提交已经形成；需要仓库所有者批准 push 或 PR 后取得新的 Windows CI / CodeQL 结果，并决定公开 RC2 ZIP 内嵌旧哈希文档的处理方式。`rc_readiness.py` 的 GO 只表示 RC 门禁具备评审条件，不授权修改 `BUILD_TYPE`、push、tag、替换 GitHub 资产或发布正式 Release。`cli_startup_latency_regression` 仍是非阻断 P1，等待进一步真实用户环境证据。
+
+## 5. 当前工作树注意事项
+
+接管时工作树可能包含尚未提交的 RC2 验收文档。2026-08-28 整理时已有：
+
+```text
+docs/KNOWN_ISSUES.md
+docs/RC_BUILD_NOTES.md
+docs/RC_SMOKE_TEST.md
+rc2_item14_codex.md
+rc2_smoke_codex.md
+rc2_vm_status.md
+```
+
+这些属于已有工作，不得丢弃、reset 或覆盖。先阅读 `git diff`，再做增量归并。工作区集中化新增的 `AGENTS.md`、`START_HERE.md`、`docs/WORKSPACE_MAP.md` 和 `.gitignore` 修改同样可能尚未提交。
+
+## 6. 验证与完成标准
+
+代码或权威状态变更完成后至少执行：
+
+```powershell
+py -B -m unittest discover -s tests -p "test_*.py" -v
+py -B scripts/verify_project_state.py
+py -B scripts/rc_readiness.py
+```
+
+接手者结束工作前必须留下：
+
+- 当前结论与下一步；
+- 修改文件清单；
+- 实际执行的验证命令和结果；
+- 尚未解决的风险或证据缺口；
+- 是否触及发布、push、tag、VM 或外部工具状态。
+
+未经用户明确授权，不得 push、merge、rebase、reset、clean、tag、发布 Release、上传产物或修改仓库设置。

--- a/docs/CURRENT_STATUS.md
+++ b/docs/CURRENT_STATUS.md
@@ -1,17 +1,17 @@
 # Current Status — 0.1.0 RC2
 
-Last verified: `2026-08-24`  
+Last verified: `2026-08-28`
 App version: `0.1.0`  
 Build: `Release Candidate`  
 Test baseline: `py -B -m unittest discover -s tests -v` → `Ran 234 tests — OK (skipped=7)`
 Current P0: 无。`mixed_selected_and_ambiguous_content_silent_nondelivery`已完成自动与真实P0修复验证。  
-Current next action: 试用已公开并标记 GitHub Latest 的 RC2；安全修复后的干净 Win11/Win10 VM 复验仍待完成，Latest 不代表稳定版门禁通过。
+Current next action: RC2 干净 Win11 门禁证据已归并并通过；本地 `main` 当前比 `origin/main` 超前 1 个提交，完成隐私清理后可按仓库所有者授权 push。Windows 10 仍为可选未测，RC 身份不会自动变为正式 Release。
 
 ## Current baseline
 
 - 自动测试：`py -B -m unittest discover -s tests -v`
 - 当前实际结果：`Ran 234 tests — OK (skipped=7)`。
-- 当前状态：0.1.0 RC2；自动化与本机构建验证通过，安全修复后的干净 Win11/Win10 VM 复验待完成。
+- 当前状态：0.1.0 RC2；自动化、本机构建和当前交付 RC2 的干净 Win11 VM 复验通过。Windows 10 可选未测。
 - 核心冻结：是。当前不是新功能扩展阶段。
 
 ## Resolved P0
@@ -29,7 +29,7 @@ Issue ID：`password_candidate_history_pollution`
 
 - 平台过滤已改为 opt-in：`ignore_android=False`、`ignore_AZ=False`。旧配置显式 `true` 仍然有效，INITIAL_SCAN/PIPELINE_SCAN都使用同一 Settings。
 - `apk_content_container_recursive_unpack`：RESOLVED。ArchiveAnalyzer 仍如实报告 ZIP；ArchiveFinder 在自动创建任务前共享 ContainerRolePolicy。APK/Office/EPUB/JAR 默认保留，显式文件输入可覆盖。
-- clean Windows 11 VM smoke test：旧 RC1 曾 PASS；RC2 因安全代码与构建内容发生变化，需要重新验证。Windows 10 仍为可选未测。
+- clean Windows 11 VM smoke test：当前交付 RC2 ZIP `BA3A9ADD…` / EXE `67DF840B…` 已 PASS。清单 1–13、15–17 见 `../rc2_smoke_codex.md`，三阶段真实 Ctrl+C 清单 14 见 `../rc2_item14_codex.md`；Windows 10 仍为可选未测。
 - KI-P0-002已解决：独立PC与Android DeliveryUnits同时交付；真正竞争根保留现有选择闭环；未决唯一内容在非交互模式下保留并报告。
 - `cli_direct_path_entry_regression`已解决：首屏直接接受文件/目录路径，M进入辅助菜单，Q退出；成功、失败或取消后返回Fast Path。
 - `cli_startup_latency_regression`保留为NEEDS_REAL_ENVIRONMENT_VERIFICATION。开发机T1/T2约0.181秒、T3约0.000128秒，未采用lazy初始化。
@@ -37,7 +37,7 @@ Issue ID：`password_candidate_history_pollution`
 - NEXT-1人工密码恢复闭环已完成：非交互默认仍返回结构化失败；交互CLI支持安全输入、跳过和取消。
 - AZ平台过滤误判已解决：只接受明确ASCII token，并只检查任务内容根以下的相对组件；历史记录保留在`KNOWN_ISSUES.md`。
 - 历史 `RELEASE_CANDIDATE_REPORT.md` 仍保留当时的 `Development/103 tests` 证据；当前 RC 构建说明与基线以本文件、`RC_BUILD_NOTES.md` 和 `project_state.json` 为准。
-- RC2 的 Win11 门禁待重新验证，保持 `BUILD_TYPE=Release Candidate`，不自动改成正式 Release。
+- RC2 的 Win11 门禁已关闭；仍保持 `BUILD_TYPE=Release Candidate`，只有完成最终发布清单并得到仓库所有者明确批准后才可评估正式 Release。
 
 ## Known real samples
 
@@ -64,7 +64,7 @@ Issue ID：`password_candidate_history_pollution`
 - 不要自动删除未知历史目录。
 - 不要记录密码明文或完整含密码命令行。
 - 不要为了测试通过降低结构/CRC/SHA256验证强度。
-- 不要在clean VM通过前标正式Release。
+- 不要仅凭 clean VM 门禁通过就标正式 Release；仍需完成发布清单和仓库所有者明确批准。
 
 ## Knowledge base
 
@@ -85,5 +85,5 @@ Issue ID：`password_candidate_history_pollution`
 
 - `project_state.json`：schema v1，当前版本/构建/测试基线/P0/release gates已同步。
 - `scripts/verify_project_state.py`：最终结果见本次治理检查；schema、版本、文档、协议、密码泄漏、开发机路径、P0和不少于 `project_state.json` 已核验数量的自动测试必须一致。当前已核验 234 项。
-- `scripts/rc_readiness.py`：RC2 的 Win11 门禁未勾选，预期保持 **NO-GO**。仓库所有者确认将 RC2 标记为 GitHub Latest；该展示状态不改变 Release Candidate 身份，也不等于稳定版门禁通过。
+- `scripts/rc_readiness.py`：RC2 的必选机器门禁已同步，预期返回 **GO**。GO 表示 RC 发布门禁具备评审条件，不自动改变 Release Candidate 身份，也不授权 push、tag 或发布正式 Release。
 - Windows 10 VM当前为可选门禁，未验证不会单独阻止0.1.0 RC，但必须如实报告。

--- a/docs/GO_NO_GO_OWNER.md
+++ b/docs/GO_NO_GO_OWNER.md
@@ -1,0 +1,29 @@
+# RC2 所有者 Go/No-Go 短包
+
+核对时间：2026-09-02（Asia/Shanghai）。
+
+## 结论
+
+**现在不能称为正式版。** 当前身份仍为 `0.1.0 Release Candidate`。RC 门禁为 **GO**，仅表示具备所有者最终评审条件，不授权 push、tag、替换资产或正式发布。
+
+## Git 与工作树
+
+- 本地 `main` 相对 `origin/main` 超前 1；该提交尚未推送。
+- 本轮新增未提交 `docs/GO_NO_GO_OWNER.md`，并在 `docs/CURRENT_STATUS.md` 增加一行 next action。
+- 本轮未 push、未创建 tag、未改 VM、`BUILD_TYPE` 或发布门禁。
+
+## 发布前剩余的所有者决策
+
+1. 将隐私清理后的本地提交通过 push 或 PR 送出；送出后才可取得新的 Windows CI / CodeQL 结果。
+2. 公开 RC2 ZIP 内嵌旧 EXE 哈希文档的处置：保留原资产并附勘误，或重新打包为新资产并发布新的 ZIP SHA-256。
+3. 是否改为正式 Release（包括修改 `BUILD_TYPE`）；这必须在上述事项完成后另行明确批准。
+
+## 默认建议
+
+**不 push、不重打包、不改 `BUILD_TYPE`**，直到仓库所有者在本轮明确授权。原始 RC2 ZIP 保持不变。
+
+## 依据与风险
+
+- 发布审计：[`RELEASE_AUDIT_2026-08-28.md`](RELEASE_AUDIT_2026-08-28.md)。
+- 机器状态：[`../project_state.json`](../project_state.json)，其中 Win11 必选门禁已关闭；Windows 10 是可选、未测试项。
+- 原始 ZIP 内旧文档哈希与实际 EXE 哈希不一致；这不否定已测二进制，但在替换资产或正式发布前必须显式决策。

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -95,15 +95,16 @@
 - **Fix**：`max(indexed)==1` 时补下一卷（保留现有宽度：`part2` 或 `part02`）。完整 `part01+part02` 仍可执行。
 - **Do not fix by**：不要按扩展名猜测；不要把普通 `name.rar` 当成分卷；不要为过报告放宽 7z 缺卷规则。
 - **Regression coverage**：`part01` 缺卷不进 Extractor；`part1` 宽度匹配 `part2`；完整 `part01+part02` 可执行；既有 RAR/7z/zip 分卷分组；ApplicationService 报告 `VOLUME_DETECTION`/`MISSING_VOLUME`。完整 228 项通过。
-- **Remaining**：桌面 8/22 旧包未覆盖。Win10 可选未测。Win11 整包门禁已勾。
+- **Remaining**：桌面 8/22 旧包未覆盖。Win10 可选未测。当前 RC2 已验证此缺卷修复，整包 Win11 门禁已完成。
 
-### KI-P1-001：干净Windows VM尚未完成最终GO
+### KI-P1-001：干净 Windows VM 最终门禁
 
-- **Status**：RESOLVED for clean Windows 11（2026-08-24）；Windows 10 仍 OPTIONAL / NOT VERIFIED。
+- **Status**：RESOLVED for current RC2 on clean Windows 11（2026-08-28）；Windows 10 仍 OPTIONAL / NOT VERIFIED。
 - **Affected modules**：RC构建、runtime paths、ToolManager、配置、日志/history。
 - **Real sample**：测试游戏1～6中的可合法复制测试集合；RC 烟测夹具见 `.vm_gate` 记录。
-- **Win11 evidence**：EXE `9BFDE4CE…`；无 Python；工具发现；ZIP/RAR/7Z/LZ4；分卷含 RAR part01 缺卷；JPEG 内嵌；中文路径；人工密码；Ctrl+C 于 EXTRACTING/SCANNING/VALIDATING；源哈希不变；明文 0 hit。
-- **Remaining**：Win10 可选未测。桌面 8/22 旧包未覆盖。
+- **Win11 evidence**：当前 RC2 EXE `67DF840B…`（ZIP `BA3A9ADD…`）的清单 1–13、15–17 见 `../rc2_smoke_codex.md`；清单 14 已在 `Win11-Sandbox` GUI 会话中向 EXTRACTING、SCANNING、VALIDATING 三阶段发送真实 Ctrl+C 扫描码，应用均报告 `KeyboardInterrupt`、保留 `ORPHANED_TEMP`，源哈希不变且随后重跑成功，见 `../rc2_item14_codex.md`。旧 EXE `9BFDE4CE…` 与 `F5F2DD82…` 不作为当前门禁替代证据。
+- **Artifact note**：被测 ZIP 内附带的旧 Markdown 仍写有旧 EXE 哈希；实际 ZIP/EXE 哈希已由宿主 staging、VM 和三个字节一致的 ZIP 副本交叉确认。原始 ZIP 保持不变作为证据，源码权威文档已纠错。若以后重新打包，必须发布新 ZIP 哈希并确认 EXE 仍为 `67DF840B…`，不得把文档更新包装成原 ZIP 未变化。
+- **Remaining**：Win10 可选未测。桌面 8/22 旧包未覆盖。正式 Release 仍需单独完成发布清单和仓库所有者批准。
 - **Do not fix by**：不要因为 Win11 GO 就把 `BUILD_TYPE` 改成正式 Release；不要捆绑来源或许可未确认的外部工具。
 
 ### KI-P1-002：旧RC文档的历史基线已过时
@@ -112,7 +113,7 @@
 - **Affected modules**：`RELEASE_CANDIDATE_REPORT.md`、`RC_BUILD_NOTES.md`。
 - **Real sample**：不适用。
 - **Risk**：新接手者可能误认为当前仍是Development或只有103/107项测试。
-- **Current workaround**：以`CURRENT_STATUS.md`、`project_state.json`和当前实测为准；当前是0.1.0 Release Candidate、224项测试。
+- **Current workaround**：以`CURRENT_STATUS.md`、`project_state.json`和当前实测为准；当前是0.1.0 Release Candidate、234项测试。
 - **Do not fix by**：不要静默改写历史报告使其看起来当时就是当前状态；应保留历史并明确时间点。
 
 ### KI-P1-003：测试游戏4发布签字前需要重新真实回归

--- a/docs/RC_BUILD_NOTES.md
+++ b/docs/RC_BUILD_NOTES.md
@@ -46,13 +46,27 @@ dist/
 dist\GameArchiveManager-0.1.0-RC2\GameArchiveManager.exe
 ```
 
-构建时 EXE SHA256：
+当前交付 RC2 ZIP SHA256（开发机 staging 与 Win11-Sandbox 一致）：
+
+```text
+BA3A9ADD4132EFF6188E3981C627400647941C572059F3D733347A3EE6823051
+```
+
+当前交付 RC2 EXE SHA256（开发机 staging 与 Win11-Sandbox 一致）：
+
+```text
+67DF840B832EE9072375A3A267DF220DBB546FD61EF8B048EA8C8C6B17D20F71
+```
+
+以下两个 SHA256 属于 2026-08-24 的旧门禁包，不是当前交付 RC2：
+
+- 可见密码 CLI 重建包：
 
 ```text
 F5F2DD823664AA2ABFE52A7C91597EA4FA3735E9C3EC8FF0E7A8813D9B92D83C
 ```
 
-此前 2026-08-24 Win11 门禁包（隐藏密码 / getpass）EXE SHA256：
+- 隐藏密码 / `getpass` 门禁包：
 
 ```text
 9BFDE4CE679EDF819AB4CB19E7E29FC6B4D5206134BA63D5739C6F87E27D0AD0
@@ -64,7 +78,7 @@ F5F2DD823664AA2ABFE52A7C91597EA4FA3735E9C3EC8FF0E7A8813D9B92D83C
 F825C3859C85B1FDA9BE5809E1DB6BA447FC3478316870EEB2813F46AF472490
 ```
 
-如果重新构建，哈希可能变化，交付前必须重新计算并更新测试记录。
+如果重新构建或重新打包，EXE 或 ZIP 哈希可能变化，交付前必须重新计算并更新测试记录。
 
 ## 构建依赖
 
@@ -198,14 +212,19 @@ GameArchiveManager\        NO_MATCH
 ## 已知限制
 
 - 当前是控制台 RC，没有 GUI。
+- 没有持久密码库；成功密码只在当前进程的 `SessionPasswordStore` 中短暂复用。
+- RAR/7Z 的等价内容预检查能力有限，最终仍依赖外部工具验证和解压后安全检查。
+- 没有暂停/恢复功能，也没有持久化 Pipeline 队列。
 - 外部工具需用户合法安装或配置。
 - LZ4 未随 RC 捆绑。
-- 打包版仅在当前 Windows 11 开发机完成首次冒烟，仍需干净 VM 结果。
+- 当前交付 RC2 ZIP `BA3A9ADD…` / EXE `67DF840B…` 已完成干净 Windows 11 VM 冒烟；证据见 `../rc2_smoke_codex.md` 与 `../rc2_item14_codex.md`。
+- 原始 RC2 ZIP 内附带的 `RC_BUILD_NOTES.md` / `RC_SMOKE_TEST.md` 仍包含旧 EXE 哈希；被测原包保持不可变，当前源码文档记录实际交付哈希。重新打包会产生新的 ZIP 哈希，必须作为新的交付身份处理。
 - Windows 10 尚未实际验证。
 - 没有代码签名，Windows SmartScreen 可能显示未知发布者提示。
 - 没有安装程序；必须整体复制 onedir，不能只复制 EXE。
+- `CleanupManager.delete()` 是受边界与授权保护的永久删除，不经过回收站；应用默认不会删除源归档或未知用户目录。
 - 本构建不是正式 Release，不得对外宣称稳定正式版。
 
 ## VM 测试结论状态
 
-当前状态：**等待干净 Windows VM 测试，不自行宣称发布完成。**
+当前状态：**干净 Windows 11 VM 门禁 PASS；Windows 10 可选未测。** 这只关闭 RC 必选机器门禁，不自动授权正式发布或把 `BUILD_TYPE` 改为 Release。

--- a/docs/RC_SMOKE_TEST.md
+++ b/docs/RC_SMOKE_TEST.md
@@ -31,17 +31,23 @@
 GameArchiveManager-0.1.0-RC2\
 ```
 
-在开发机交付记录中核对目录哈希或至少核对 EXE SHA256：
+在开发机交付记录中核对 RC2 ZIP 与 EXE SHA256：
 
 ```powershell
+Get-FileHash .\GameArchiveManager-0.1.0-RC2.zip -Algorithm SHA256
 Get-FileHash .\GameArchiveManager-0.1.0-RC2\GameArchiveManager.exe -Algorithm SHA256
 ```
 
-本次构建记录值：
+当前交付 RC2 实测值（开发机 staging 与 Win11-Sandbox 一致）：
 
 ```text
-9BFDE4CE679EDF819AB4CB19E7E29FC6B4D5206134BA63D5739C6F87E27D0AD0
+ZIP  BA3A9ADD4132EFF6188E3981C627400647941C572059F3D733347A3EE6823051
+EXE  67DF840B832EE9072375A3A267DF220DBB546FD61EF8B048EA8C8C6B17D20F71
 ```
+
+`9BFDE4CE679EDF819AB4CB19E7E29FC6B4D5206134BA63D5739C6F87E27D0AD0`
+与 `F5F2DD823664AA2ABFE52A7C91597EA4FA3735E9C3EC8FF0E7A8813D9B92D83C`
+属于 2026-08-24 的旧门禁包，不是当前交付 RC2 的身份哈希。
 
 ## 测试记录模板
 
@@ -375,4 +381,13 @@ Get-FileHash '<源压缩包路径>' -Algorithm SHA256
 
 ## 测试完成后的状态
 
-不要自行把 RC 改称正式 Release。提交完整记录、截图和问题清单，等待 Go/No-Go 评审。
+2026-08-28 当前交付 RC2 的必选 Windows 11 VM 清单已完成：
+
+- ZIP SHA256：`BA3A9ADD4132EFF6188E3981C627400647941C572059F3D733347A3EE6823051`
+- EXE SHA256：`67DF840B832EE9072375A3A267DF220DBB546FD61EF8B048EA8C8C6B17D20F71`
+- 清单 1–13、15–17：PASS，完整记录见 [`../rc2_smoke_codex.md`](../rc2_smoke_codex.md)。
+- 清单 14：EXTRACTING、SCANNING、VALIDATING 三阶段真实 Ctrl+C 与中断后重跑均 PASS，见 [`../rc2_item14_codex.md`](../rc2_item14_codex.md)。
+- VM 关机与残留宿主 GUI 清理时间线见 [`../rc2_vm_status.md`](../rc2_vm_status.md)。
+- 被测 ZIP 内附带文档写有旧 EXE 哈希，但实际 ZIP/EXE 身份已在宿主、来宾和三份字节一致的 ZIP 副本间核对；原始被测 ZIP 未被修改。
+
+结论：Clean Windows 11 RC gate **GO**。Windows 10 为可选未测。不要自行把 RC 改称正式 Release；仍须完成发布清单并等待仓库所有者批准任何 push、tag 或发布动作。

--- a/docs/RELEASE_AUDIT_2026-08-28.md
+++ b/docs/RELEASE_AUDIT_2026-08-28.md
@@ -1,0 +1,80 @@
+# GameArchiveManager 0.1.0 RC2 发布审计
+
+审计日期：2026-08-28（Asia/Shanghai）
+
+## 结论
+
+**RC 门禁：GO，可提交仓库所有者最终 Go/No-Go 评审。**
+
+这不是正式发布授权。当前仍是 `0.1.0 Release Candidate`。本轮集中化与门禁归并已形成一个本地 Git 提交；未执行 push、tag、GitHub Release 修改或资产替换。
+
+## 被审计对象
+
+| 对象 | 身份 |
+| --- | --- |
+| Git 已提交基线 | `85a95bc3ae60aafe816650e8df367fe5b11a86c6` |
+| 原始 RC2 ZIP | `BA3A9ADD4132EFF6188E3981C627400647941C572059F3D733347A3EE6823051` |
+| ZIP 内实际 EXE | `67DF840B832EE9072375A3A267DF220DBB546FD61EF8B048EA8C8C6B17D20F71` |
+| 构建身份 | `0.1.0 / Release Candidate` |
+| 必选 VM | `Win11-Sandbox`，Windows 11 Home 25H2，普通用户，无可用 Python 开发环境 |
+
+三个保存位置中的原始 RC2 ZIP 字节一致，均为 `BA3A9ADD…`。被测原包保持不变。
+
+## 证据分层
+
+### 自动化与治理
+
+- `py -B -m unittest discover -s tests -q`：`Ran 234 tests`，`OK`。
+- `py -B scripts/verify_project_state.py`：`Overall: PASS`。
+- `py -B scripts/rc_readiness.py`：Clean Windows 11 VM `PASS`，Overall `GO`。
+- `py -B scripts/check_markdown_links.py`：33 个 Markdown 文件通过。
+- `git diff --check`：无空白错误；仅有 Windows 工作树 LF/CRLF 提示。
+
+自动化覆盖格式识别、真实 ZIP/RAR/7Z/LZ4、伪装文件、递归与分卷、密码恢复、工具缺失、解压前后配额、路径穿越、符号链接/reparse point、平台过滤、交付去重、Cleanup 边界、历史编码、日志脱敏、配置优先级和持续 CLI 会话。
+
+### 干净 Windows 11 VM
+
+- 清单 1–13、15–17：[`../rc2_smoke_codex.md`](../rc2_smoke_codex.md)。
+- 清单 14 三阶段真实 Ctrl+C 与中断后重跑：[`../rc2_item14_codex.md`](../rc2_item14_codex.md)。
+- 来宾正常关机和宿主 GUI 残留清理：[`../rc2_vm_status.md`](../rc2_vm_status.md)。
+- 截图和受控夹具：本地 `.vm_gate/`，由 `.gitignore` 排除，不进入公开源码包。
+
+VM 已验证：无 Python 启动、版本身份、开发机路径独立、无工具结构化失败、7-Zip/WinRAR/LZ4 发现、普通格式、复合包、分卷与缺卷、密码成功/错误/跳过、JPEG 内嵌 RAR、中文路径、重复运行、最终输出隔离、日志/history、源 SHA-256、Cleanup 边界以及 EXTRACTING/SCANNING/VALIDATING 中断。
+
+### 本机静态与启动检查
+
+- 源码环境：Python 3.13.2，满足 Python 3.10+。
+- `requirements.txt` 为 0 字节；唯一构建依赖为 `pyinstaller==6.21.0`。
+- 向 `py -B main.py` 输入 `Q`：显示 `0.1.0 / Release Candidate` 和工具状态，退出码 0。
+- Git 跟踪文件中没有 EXE、DLL、归档、ISO、私钥或日志文件；开发路径扫描只命中 `<redacted>` 示例。
+- `.project_archive/`、`.vm_gate/`、构建目录、日志和交接二进制均由 `.gitignore` 排除。
+- ConfigLoader 的白名单与 `docs/CONFIGURATION.md` 一致：14 个字段；未知/非法/越界值告警，缺失值回退默认，相对工具路径按配置目录解析，输出配额允许显式 `null`。
+- GameLogger 和 HistoryStorage 的目录/写入异常不会被静默吞掉；ApplicationService 会记录历史保存异常类型。密码与外部错误输出受脱敏和长度限制。
+- `docs/SECURITY.md` 已明确 `CleanupManager.delete()` 是不经过回收站的永久删除，并记录授权边界。
+
+## RC2 内嵌文档哈希差异
+
+原始 ZIP 内的旧 `RC_BUILD_NOTES.md` / `RC_SMOKE_TEST.md` 分别引用 `F5F2DD82…`、`9BFDE4CE…`，而 ZIP 内实际 EXE 是 `67DF840B…`。处理原则：
+
+1. 原始被测 ZIP 不修改，保持 VM 证据可复核；
+2. 当前源码权威文档记录实际 ZIP/EXE 身份并明确旧哈希来源；
+3. 不声称原 ZIP 内文档已经正确；
+4. 若重新打包文档，即使 EXE 不变，ZIP SHA-256 也会变化，必须视为新的交付资产并发布新校验值。
+
+该差异不否定已测试二进制的身份或运行结果，但必须在任何资产替换或正式发布决策中显式处理。
+
+## 已知非阻断项
+
+- Windows 10 VM：可选、未测试。
+- `cli_startup_latency_regression`：P1，开发机无法复现严重延迟；等待更多真实用户环境证据。
+- EXE 未代码签名，SmartScreen 可能显示未知发布者。
+- 控制台应用，无 GUI、安装程序、持久密码库、暂停/恢复或持久 Pipeline 队列。
+- LZ4 CLI、7-Zip 和 WinRAR 不随项目捆绑。
+
+## 发布前仍需完成
+
+1. 在 push 或 PR 后取得新的 Windows CI / CodeQL 结果；本地提交本身不会产生远端 CI 证据。
+2. 由仓库所有者决定如何处理公开 RC2 ZIP 的内嵌旧哈希文档：保留原资产并附勘误，或发布具有新 ZIP 哈希的替代资产。
+3. 任何 push、tag、GitHub Release 修改、资产上传或正式 Release 身份变更均需仓库所有者明确批准。
+
+在以上事项完成前，可以称为“RC 门禁 GO、等待最终发布操作”，不能称为“正式稳定版已经发布”。

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,5 +1,7 @@
 # GameArchiveManager 0.1.0 RC 发布检查清单
 
+> 2026-08-28 的实际证据归并与剩余发布动作见 [`RELEASE_AUDIT_2026-08-28.md`](RELEASE_AUDIT_2026-08-28.md)。本文件保留可重复执行的逐项模板；未机械回填的方框不应覆盖审计报告、自动化、VM 证据或 `project_state.json` 的实际状态。
+
 本清单用于当前 Release Candidate 的发布门禁验收。带 `[ ]` 的项目必须由发布人员逐项确认；不要因为自动测试通过就跳过真实压缩包、真实 Windows 文件系统和磁盘安全测试。当前仍是 RC，不代表正式 Release。
 
 ## 1. 环境检查
@@ -129,13 +131,13 @@
 - [ ] 在干净的 Windows 测试目录中重新运行完整自动测试。
 - [ ] 完成人工 ZIP、RAR、7Z、LZ4、RAR.LZ4、密码、分卷、嵌入归档和递归测试记录。
 - [ ] 在发布说明中列出当前未实现或受限功能：GUI、持久密码库、RAR/7Z 等价内容预检查、暂停/恢复及持久化 Pipeline 队列。
-- [ ] 执行 `py scripts/verify_project_state.py`，确认治理状态与至少 224 项自动测试一致。
-- [ ] 执行 `py scripts/rc_readiness.py`；在 Clean Windows 11 VM 门禁真实完成前，结果必须保持 `NO-GO`，不得自行改为正式发布。
+- [x] 2026-08-28 执行 `py -B scripts/verify_project_state.py`：`Overall: PASS`，并核验 234 项自动测试。
+- [x] 2026-08-28 执行 `py -B scripts/rc_readiness.py`：Clean Windows 11 VM 门禁归并后结果为 `GO`；不得据此自行改为正式发布。
 - [ ] 至少由另一名测试人员复核危险删除、密码脱敏和原文件保留项目。
 
 ## RC 发布结论
 
 - [ ] 所有阻断项已通过。
 - [ ] 所有未通过项目已有明确的已知限制说明和风险接受记录。
-- [ ] Clean Windows 11 VM 冒烟门禁已完成并保存证据。
-- [ ] 0.1.0 RC 可以提交最终 Go / No-Go 评审；不得直接标记为正式 Release。
+- [x] Clean Windows 11 VM 冒烟门禁已完成并保存证据。
+- [x] 0.1.0 RC 可以提交最终 Go / No-Go 评审；不得直接标记为正式 Release。

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -63,7 +63,7 @@
 - **NEXT-1：密码失败后的人工恢复闭环**：已完成。自动候选耗尽后可由可选回调安全输入、跳过或取消；成功密码只在当前进程的 SessionPasswordStore 中保留。
 - **NEXT-2：CLI Session Loop**：已完成。启动一次后可连续提交单/批量任务、查看最近结果、工具与设置并主动退出。Settings、ToolManager、HistoryStorage、ApplicationService和SessionPasswordStore复用；Task、Pipeline/Guard/runtime state、TaskReport及task-level candidates每次重建。
 
-下一阶段不再增加0.1.0功能，进入Release Validation：测试游戏4签字级真实回归，必要时复跑3/5/6，然后执行clean Windows 11 VM并重新评估GO/NO-GO。
+0.1.0 的真实样本签字回归与 clean Windows 11 VM 门禁已经完成。下一阶段不增加功能，进入最终 Release Checklist 与仓库所有者 Go/No-Go 评审；Windows 10 仍为可选未测。
 
 ## Phase 3：Content Root 抽象
 

--- a/docs/WORKSPACE_MAP.md
+++ b/docs/WORKSPACE_MAP.md
@@ -1,0 +1,52 @@
+# GameArchiveManager 工作区地图
+
+最后整理：2026-08-28（Asia/Shanghai）
+
+## 唯一入口
+
+今后所有 agent 和人工维护统一从下面的路径进入项目：
+
+```text
+C:\Users\<redacted>\Documents\GameArchiveManager
+```
+
+该路径是一个 Windows 目录联接，固定指向实际 Git 工作树：
+
+```text
+C:\Users\<redacted>\Documents\GameArchiveManager0.1.0
+```
+
+不要再在 GrokWork、Documents\Codex 或带“副本”的目录中继续开发。它们的原始内容已经集中到主工作树的 `.project_archive`，仅供追溯。
+
+## 集中后的目录
+
+```text
+.project_archive/
+├── agents/
+│   ├── grok/                 Grok 的交接、脚本、VM 记录、夹具和构建包
+│   └── codex-online-20260824/ Codex 与 Antigravity 工作树、输出和协作记录
+├── evidence/
+│   └── GameArchiveManager_Evidence/ 真实样本证据
+└── legacy/
+    └── GameArchiveManager0.1.0-copy-20260721/ 早期无 Git 副本
+```
+
+`.project_archive/` 已加入 `.gitignore`：集中保存本地历史痕迹，但不会把数 GB 的证据、二进制工具、嵌套 Git 仓库或构建产物提交到产品仓库。
+
+## 使用规则
+
+1. 产品代码、正式文档和测试只修改唯一入口下的主 Git 工作树。
+2. `.project_archive` 中的工作树和资料保持只读语义；需要吸收其中内容时，先复制到主仓库的正式位置并通过测试。
+3. 新的 VM 截图、临时构建和 agent 交接材料直接放入主工作树既有的 `.vm_gate`、`handoff_output` 或 `.project_archive` 分类，不再创建新的项目副本。
+4. 发布状态以 `project_state.json`、`docs/CURRENT_STATUS.md` 和主仓库 Git 历史为准。
+
+## 整理前来源映射
+
+| 原位置 | 集中后位置 | 说明 |
+| --- | --- | --- |
+| `C:\Users\<redacted>\GrokWork\projects\GameArchiveManager` | `.project_archive\agents\grok` | Grok 工作区 |
+| `C:\Users\<redacted>\Documents\Codex\2026-08-24\gamearchivemanager-https-github-com-hypnosysnyx-gamearchivemanager` | `.project_archive\agents\codex-online-20260824` | Codex、Antigravity 与在线发布审计工作区 |
+| `C:\Users\<redacted>\Documents\GameArchiveManager_Evidence` | `.project_archive\evidence\GameArchiveManager_Evidence` | 真实样本证据 |
+| `C:\Users\<redacted>\Documents\GameArchiveManager0.1.0 - 副本` | `.project_archive\legacy\GameArchiveManager0.1.0-copy-20260721` | 早期源码副本 |
+
+`C:\Users\<redacted>\Documents\GameArchiveManager` 本身不是重复副本，因此保留为稳定、无版本号的唯一入口。

--- a/project_state.json
+++ b/project_state.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "last_verified": "2026-08-24",
+  "last_verified": "2026-08-28",
   "project": {
     "name": "GameArchiveManager",
     "version": "0.1.0",
@@ -89,7 +89,7 @@
   "release_gates": {
     "full_test_suite": true,
     "real_sample_regression": true,
-    "clean_windows_11_vm": false,
+    "clean_windows_11_vm": true,
     "clean_windows_10_vm": false,
     "source_file_integrity": true,
     "password_leak_check": true,

--- a/rc2_item14_codex.md
+++ b/rc2_item14_codex.md
@@ -1,0 +1,75 @@
+# RC2 清单第 14 项：Win11-Sandbox 主机扫描码 Ctrl+C
+
+## 结论
+
+**PASS。** 当前 RC2 在 `EXTRACTING`、`SCANNING`、`VALIDATING` 三个阶段均由宿主机向 `Win11-Sandbox` GUI 会话发送真实 Ctrl+C 扫描码 `1d 2e ae 9d`。三次均由应用生成 `FAILED / KeyboardInterrupt` 报告并保留 `ORPHANED_TEMP`，不是强杀进程、关闭 VM、guestcontrol stdin 或用户手按。三个源压缩包 SHA256 均未改变；同目录重跑仍只发现 1 个初始压缩包并成功完成。
+
+本次未修改 `project_state.json`，`clean_windows_11_vm` 仍为 `false`；未 push，未翻门禁。
+
+## 环境与对象
+
+| 项目 | 实际值 |
+|---|---|
+| 测试时间 | 2026-08-28 12:30–13:04 +08:00 |
+| VM | `Win11-Sandbox`，可见 GUI 会话 |
+| Guest OS | Windows 11 Home 25H2，10.0.26200.9168，x64 |
+| Guest 用户 | `sandbox`，标准用户 |
+| RC2 EXE | `C:\Users\sandbox\AppData\Local\Temp\rc2\GameArchiveManager-0.1.0-RC2\GameArchiveManager.exe` |
+| EXE SHA256 | `67DF840B832EE9072375A3A267DF220DBB546FD61EF8B048EA8C8C6B17D20F71` |
+| 新测试根 | `C:\Users\sandbox\AppData\Local\Temp\rc2_item14_20260828_1233` |
+| 输入/中断通路 | `VBoxManage controlvm Win11-Sandbox keyboardputstring` + `keyboardputscancode 1d 2e ae 9d` |
+
+交接路径最初只有 hash 正确的 EXE，缺少 `_internal\python312.dll` 等 onedir 同伴文件。通过可见 guest CMD 的 `robocopy`，从上一轮已核验的 `rc2_codex_20260827\GameArchiveManager-0.1.0-RC2` 恢复同一 RC2 onedir；恢复后重新计算的 EXE SHA256 仍为上述 `67DF840B…`。没有替换成 RC1 或旧 RC2 EXE。
+
+## 源文件完整性
+
+| 用例 | 源文件 | before SHA256 | after SHA256 | 结果 |
+|---|---|---|---|---|
+| EXTRACTING | `extracting\many.7z` | `4F8CA4EEC198DCBC188D0453353AB1FB3DBC12266CA4B35F137787DA30258B08` | 同 before | PASS |
+| SCANNING | `scanning\outer.7z` | `9E566A0F12F6652F5850E7BF30EE30B788AB6E938366933AA77A4AA52C50A54F` | 同 before | PASS |
+| VALIDATING | `validating\outer.7z` | `9E566A0F12F6652F5850E7BF30EE30B788AB6E938366933AA77A4AA52C50A54F` | 同 before | PASS |
+
+before 截图：`.vm_gate/rc2_67df_item14_extract_hash_before.png`、`.vm_gate/rc2_67df_item14_scan_hash_before.png`、`.vm_gate/rc2_67df_item14_validate_hash_before.png`。
+after 截图：`.vm_gate/rc2_67df_item14_extract_hash_after.png`、`.vm_gate/rc2_67df_item14_scan_hash_after.png`、`.vm_gate/rc2_67df_item14_validate_hash_after.png`。
+
+## 三阶段中断结果
+
+| 阶段 | 目标阶段证据 | Ctrl+C 后结果 | 残留记录 |
+|---|---|---|---|
+| EXTRACTING | `rc2_67df_item14_extraction_phase.png` 的最后进度为 `EXTRACTING` | `任务状态: FAILED`；摘要和错误类型均为 `KeyboardInterrupt` | `extracting\many_extracted`，`ORPHANED_TEMP` |
+| SCANNING | `rc2_67df_item14_scanning_interrupt.png` 顶部保留中断时的 `当前阶段: SCANNING`，紧接应用失败报告 | `任务状态: FAILED`；摘要和错误类型均为 `KeyboardInterrupt` | `scanning\outer_extracted_2`，`ORPHANED_TEMP` |
+| VALIDATING | `rc2_67df_item14_validating_nested2_phase_detected.png` 的最后进度为 `VALIDATING`（`inner39.zip`） | `任务状态: FAILED`；摘要和错误类型均为 `KeyboardInterrupt` | `validating\outer_extracted_2`，`ORPHANED_TEMP` |
+
+对应失败报告截图：
+
+- `.vm_gate/rc2_67df_item14_extraction_interrupt.png`
+- `.vm_gate/rc2_67df_item14_scanning_interrupt.png`
+- `.vm_gate/rc2_67df_item14_validating_nested2_interrupt_detected.png`
+
+VALIDATING 使用 RC1 同类嵌套夹具：outer 解出 60 个 inner ZIP，流水线在第 39 个 inner ZIP 的 `VALIDATING` 阶段被捕获。宿主机截图匹配只负责确认可见阶段；确认后仍由 `VBoxManage ... keyboardputscancode 1d 2e ae 9d` 注入 Ctrl+C。
+
+## 中断后重跑
+
+| 阶段用例 | 初始预览 | 重跑结果 |
+|---|---:|---|
+| EXTRACTING | 1 | `COMPLETED`，成功 1、失败 0；输出安全递增为 `GameArchive_Output\many_2` |
+| SCANNING | 1 | 61 个流水线压缩包全部成功、失败 0；输入 `61`（全部保留）后完成交付 |
+| VALIDATING | 1 | 61 个流水线压缩包全部成功、失败 0；输入 `61`（全部保留）后完成交付 |
+
+重跑证据：
+
+- EXTRACTING：`.vm_gate/rc2_67df_item14_extraction_rerun_preview.png`、`.vm_gate/rc2_67df_item14_extraction_rerun.png`
+- SCANNING：`.vm_gate/rc2_67df_item14_scanning_rerun_preview.png`、`.vm_gate/rc2_67df_item14_scanning_rerun.png`
+- VALIDATING：`.vm_gate/rc2_67df_item14_validating_rerun_preview.png`、`.vm_gate/rc2_67df_item14_validating_rerun_status.png`、`.vm_gate/rc2_67df_item14_validating_rerun.png`
+
+嵌套用例在交付选择前报告 `COMPLETED_NEEDS_SELECTION`，随后通过宿主机 `keyboardputstring` 选择“全部保留”；最终摘要为成功 61、失败 0。旧 `ORPHANED_TEMP` 未被误扫为新的初始任务，也未在取证期间手工删除。
+
+## 范围确认
+
+- 未使用 guestcontrol 重定向或管道 stdin。
+- 未要求或使用用户键盘操作。
+- 未强杀应用、VM 或 VirtualBox 进程。
+- 未清理取证残留。
+- 未修改业务代码、版本、构建类型或 release gate。
+- 未 git push。
+- 报告不含登录密码或测试密码。

--- a/rc2_smoke_codex.md
+++ b/rc2_smoke_codex.md
@@ -1,0 +1,90 @@
+# GameArchiveManager 0.1.0 RC2 — Win11-Sandbox guestcontrol smoke
+
+> **Subsequent closure (2026-08-28):** This report preserves the initial partial-run verdict. Checklist item 14 was subsequently completed against the same EXE `67DF840B…` and passed in all three phases; see [`rc2_item14_codex.md`](rc2_item14_codex.md). The combined authoritative gate result is recorded in [`docs/RC_SMOKE_TEST.md`](docs/RC_SMOKE_TEST.md). The original tested ZIP remains unchanged, including its stale embedded Markdown hash text.
+
+## Verdict
+
+**Overall: BLOCKED / do not flip `clean_windows_11_vm` yet.**
+
+The supplied RC2 passed startup, no-tool behavior, tool discovery, real formats, split volumes, password recovery, embedded RAR, Chinese paths, repeat runs, cleanup boundaries, source-integrity checks, and persistence checks. Checklist item 14 (real Ctrl+C during EXTRACTING / SCANNING / VALIDATING) could not be completed faithfully through this guestcontrol session. In addition, the EXE hash recorded in the packaged smoke document is stale relative to the supplied RC2 ZIP.
+
+I did not change `project_state.json`, `BUILD_TYPE`, version data, frozen business code, tags, releases, or remote state. No push was performed. At the end of the run `project_state.json` still had `clean_windows_11_vm: false`.
+
+## Environment and artifact identity
+
+| Field | Observed value |
+|---|---|
+| Test window | 2026-08-27 21:35–22:15 +08:00 |
+| VM | `Win11-Sandbox` (the forbidden `GAM-RC2-Test` VM was not used) |
+| Transfer/execution channel | VirtualBox `guestcontrol` |
+| OS | Microsoft Windows 11 Home, 25H2, 10.0.26200, build 26200.9168, x64 |
+| VM snapshot | None |
+| Guest account | Standard local user (`IsAdministrator=False`) |
+| Python | No installed Python entries; `python --version` resolved only to the Microsoft Store alias and exited 9009; `py` not found |
+| Fresh test root | `%LOCALAPPDATA%\Temp\rc2_codex_20260827` |
+| Host repo HEAD | `85a95bc3ae60aafe816650e8df367fe5b11a86c6` |
+| RC2 tag commit / ZIP `BUILD_INFO.txt` source | `a09e299b485d135046b49961c9a3212914579dc3` / `v0.1.0-rc2` |
+| RC2 ZIP SHA256 | `BA3A9ADD4132EFF6188E3981C627400647941C572059F3D733347A3EE6823051` |
+| RC2 EXE SHA256 | `67DF840B832EE9072375A3A267DF220DBB546FD61EF8B048EA8C8C6B17D20F71` |
+| Extracted onedir | 67 files before adding test tools |
+
+The ZIP and EXE hashes in the guest matched the host staging ZIP byte-for-byte. The ZIP is identified as RC2 by `BUILD_INFO.txt` and points to the RC2 tag commit; this is not the RC1 binary.
+
+### Artifact documentation discrepancy
+
+The supplied ZIP's `RC_SMOKE_TEST.md` records EXE SHA256 `9BFDE4CE679EDF819AB4CB19E7E29FC6B4D5206134BA63D5739C6F87E27D0AD0`, while the actual EXE in that ZIP is `67DF840B…`. Its `RC_BUILD_NOTES.md` also calls `F5F2DD82…` the build-time hash and lists `9BFDE4CE…` as an earlier gate build. The handoff explicitly identified `67DF840B…` as the supplied RC2 guest hash, so that exact binary was tested, but the packaged integrity record should be reconciled before release.
+
+## Tool phases
+
+The fresh extracted RC2 initially had no `tools` directory and no `config.json`. It reported all three tools as not found. A real ZIP task then ended `FAILED / TOOL_NOT_FOUND`, created no final output, and preserved source SHA256 `22A2E30E7B02681C59E161E5863C1CD476159A9AA6D64F60E760BB558267F79C`.
+
+For the enabled phase, the previously license-recorded fixture tools were copied into the fresh onedir through guestcontrol:
+
+| Tool | Version | SHA256 | Detection |
+|---|---|---|---|
+| 7-Zip | 26.02 x64 | `83967F1B02B43C4EFEDA302795722C809E0E81B8307DE73558D10484D5676A7D` | PASS |
+| `7z.dll` | — | `69FD4DF057985C40E510E2FAC182881C7F85E90AA13EC703F763A8FDB2CE61F8` | PASS |
+| WinRAR CLI `Rar.exe` | 7.23 x64 | `F561764BC3E9ED208744321A89A819B562EDEAF06E203C02A06976121FDA1991` | PASS |
+| LZ4 | 1.10.0 x64 | `C2B1ECAB4289B72CE97257C699D497D3B34387E04F935FB7524C4FA17B05F248` | PASS |
+
+## Checklist results
+
+| # | Checklist item | Result | Evidence / observation |
+|---:|---|---|---|
+| 1 | No-Python startup | **PASS** | Standard user; no installed Python; Store alias exit 9009. EXE started with no `python.dll missing`, module error, traceback, UAC, or Python-install prompt. |
+| 2 | RC version information | **PASS** | Startup showed `GameArchiveManager`, `0.1.0`, `Release Candidate`; tool-enabled runs also reported the same identity. |
+| 3 | Development-machine path independence | **PASS** | No local Windows username, `GrokWork`, or development-tree marker in EXE/`_internal`. Two Markdown documents contain the expected example `GameArchiveManager0.1.0` text only; there were no runtime-binary hits or attempted host-path access. |
+| 4 | No external tools | **PASS** | Fresh onedir showed 7-Zip/WinRAR/LZ4 `NOT FOUND`; a real ZIP failed explicitly with `TOOL_NOT_FOUND`, source hash unchanged, no final output. |
+| 5 | 7-Zip re-detection | **PASS** | Fresh restart detected sibling `tools\7z.exe`, version 26.02, usable with matching `7z.dll`. |
+| 6 | WinRAR CLI detection | **PASS** | Detected sibling `tools\Rar.exe`, version 7.23, usable CLI (not GUI-only discovery). |
+| 7 | LZ4 detection | **PASS** | Detected sibling `tools\lz4.exe`, version 1.10.0, usable. |
+| 8 | Ordinary formats | **PASS** | ZIP, 7Z, RAR, LZ4, and composite RAR.LZ4 each ended `COMPLETED`, `failed_count=0`; expected payload delivered; every source hash unchanged. |
+| 9 | Split volumes | **PASS** | Complete 7z `.001`–`.004` previewed one archive and restored `large.bin` (180000 bytes). Complete RAR `part1`–`part4` previewed one archive and restored its 180000-byte payload. Lone first parts failed before extraction with both `VOLUME_DETECTION` and `MISSING_VOLUME`, no final output, source hashes unchanged. |
+| 10 | Password archives | **PASS** | Automatic one-time candidate completed; wrong manual entry followed by correct entry completed with two manual attempts; all-wrong then skip ended `FAILED` with final `WRONG_PASSWORD` and no final output. Source hashes unchanged. Searches found zero plaintext password hits in logs, history, or captured stdout evidence. |
+| 11 | JPEG + embedded RAR | **PASS** | JPEG+plain RAR and JPEG+encrypted RAR5 both detected embedded RAR and ended `COMPLETED`, recovering expected files with source hashes unchanged. A separate directory containing a normal JPEG, DLL, EXE, Unity `.assets`, and one ZIP previewed only one archive; the four non-archives remained untouched. |
+| 12 | Chinese paths | **PASS** | Chinese task directory, archive name, and internal filename completed without mojibake; console echoed the correct path; two safe incremented output directories existed after repeat harness passes; source hash unchanged. History remained UTF-8-readable. |
+| 13 | Repeat run | **PASS** | A fresh repeat case ran three consecutive times: all `COMPLETED`, preview count stayed `1, 1, 1`, outputs were `archive`, `archive_2`, `archive_3`, and source hash stayed unchanged. |
+| 14 | Ctrl+C at EXTRACTING / SCANNING / VALIDATING | **BLOCKED** | Redirected guestcontrol stdin is not interactive in VirtualBox 7.2.16. A guest console-control harness failed to observe/send a verified phase-specific Ctrl+C and wedged the guestcontrol/COM session. No phase was claimed as PASS and no force-kill was substituted as evidence. The three current-RC2-hash interruption cases remain unproven in this run. |
+| 15 | Final output directory | **PASS** | Final outputs were under each task's `GameArchive_Output`; repeated results incremented safely. No `password_attempt_*`, extracted-temporary, or scan-temporary directory appeared in final output. |
+| 16 | History, logs, reports | **PASS** | Data remained under `%LOCALAPPDATA%\GameArchiveManager`; app onedir contained no `logs` or `history`. History was UTF-8-readable and new records/logs carried `0.1.0 / Release Candidate`; password searches had zero hits. |
+| 17 | Safety verification | **PASS** | Tested source archives retained pre-run SHA256. Original task directories and old outputs remained present. The deliberately unknown `keep_extracted\user_file.txt` survived cleanup. No cleanup crossed a test-task boundary. |
+
+Windows 10 (environment B) was not run; the checklist marks it conditional.
+
+## Blocking infrastructure state
+
+During item 14, allocating a console inside a guestcontrol-launched PowerShell process wedged the VirtualBox guestcontrol clients. I terminated only the stuck host-side `VBoxManage` client processes and restarted `VBoxSVC`; I did not hard-power-off the VM. The headless `Win11-Sandbox` VM process remained alive, but the new service could not reacquire its machine lock (`VBOX_E_VM_ERROR` / `E_FAIL`), and a non-destructive ACPI power-button request was refused for the same reason. Teardown therefore remains blocked; the VM process was intentionally left untouched rather than force-killed.
+
+## Evidence locations
+
+- Guest root: `%LOCALAPPDATA%\Temp\rc2_codex_20260827`
+- Guest machine-readable summary: `%LOCALAPPDATA%\Temp\rc2_codex_20260827\evidence\core_summary.json`
+- Guest per-case stdout: `%LOCALAPPDATA%\Temp\rc2_codex_20260827\evidence\*.output.txt`
+- Local boot screenshot: `.vm_gate\rc2_codex_boot.png`
+- Local guest runner source: `.vm_gate\rc2_codex_core.ps1`
+
+No credential or test password is included in this report.
+
+## Gate recommendation
+
+**Do not check `clean_windows_11_vm` yet.** Re-run checklist item 14 against EXE `67DF840B…` using a restored guestcontrol session or an interactive console path, capture all three phase-specific Ctrl+C results plus reruns, and reconcile the packaged EXE hash documentation. If those checks pass without a product failure, the remaining results in this report support recommending the gate.

--- a/rc2_vm_status.md
+++ b/rc2_vm_status.md
@@ -1,0 +1,32 @@
+# RC2 虚拟机与清单 14 任务状态
+
+最后更新：2026-08-28 21:13 +08:00
+
+## 结论
+
+- **清单 14 的 Codex 任务已经正常结束，目前没有继续运行。** `rc2_item14_codex.md` 已于 2026-08-28 13:06:59 +08:00 完整写出，结论为 `PASS`，并记录三阶段中断取证及中断后重跑成功。宿主机进程检查未发现仍在运行的清单 14 `codex.exe` 或 `dispatch.py`；现有本仓库相关进程仅属于本次状态检查任务。综合现有证据，清单 14 是完成后退出，没有被强杀的迹象。
+- **`Win11-Sandbox` 已结束运行，目前没有运行中的 VM。** 21:05 后先发送 ACPI 电源按钮，但来宾未响应；随后在已退出 GameArchiveManager、哈希证据已落盘的空闲 `cmd.exe` 中执行 Windows 自身的 `shutdown /s /t 0`。屏幕显示“正在关机”，VirtualBox 日志记录来宾服务正常结束、`RUNNING -> POWERING_OFF -> OFF`、统计结束和虚拟键盘卸载。来宾已关机后，VirtualBox GUI 外壳仍长时间卡在 `stopping`；经用户明确批准，只强制结束命令行精确匹配该 VM 的 3 个残留 `VirtualBoxVM.exe`。因此 VirtualBox 管理状态最终显示 `aborted`，但该标记发生在日志已经记录 VM `OFF` 之后，不代表测试过程中或来宾运行中被强杀。
+- **可以并行运行不同工作目录的 Codex 任务，但不能让两套任务同时争用同一台 VM 的键盘注入。** 同一台 `Win11-Sandbox` 的 `keyboardputstring` / `keyboardputscancode` 属于共享输入通道；并行注入会造成按键交错、窗口焦点错位和取证失真。需要使用该 VM 的任务应串行执行，或分别使用不同 VM。
+
+## 宿主机进程观察
+
+检查时，本仓库路径相关的 `dispatch.py` / `codex.exe` 进程树只有正在生成本报告的状态检查任务（启动于 2026-08-28 13:20:15–13:20:16 +08:00）。未发现命令行属于清单 14 执行任务的存活进程。本状态检查任务写完报告后会自行退出。
+
+关机收尾后，`VBoxManage list runningvms` 为空；命令行匹配 `Win11-Sandbox` UUID 的 `VirtualBoxVM.exe` 数量为 0。没有终止 `VBoxSVC`、其他 VM 或项目进程。
+
+## 关机证据
+
+- 来宾关机命令：Windows `shutdown /s /t 0`。
+- VirtualBox 日志：`Changing the VM state from 'RUNNING' to 'POWERING_OFF'`，随后 `POWERING_OFF` 到 `OFF`。
+- 最终运行列表：空。
+- 最终残留 VM 进程：0。
+- VDI 最后写入时间：2026-08-28 21:07:05 +08:00；残留 GUI 进程于 21:12:57 +08:00 清理。
+- 未执行 `VBoxManage controlvm poweroff`，未在来宾仍运行时强制断电。
+
+## 范围确认
+
+- 未翻门禁，未修改 `project_state.json`。
+- 未修改产品代码。
+- 清单 14 执行阶段未关闭或控制 VM；本次后续收尾在用户明确批准后正常关闭来宾，并在来宾已经 OFF 后清理卡住的 VirtualBox GUI 外壳。
+- 未运行测试。
+- 未 git push。


### PR DESCRIPTION
Owner-authorized publish of RC2 workspace/docs after redacting local Windows username and absolute profile paths. Does not change BUILD_TYPE, does not retag, does not rebuild the RC2 ZIP. Local unpublished commit 12c0448 was rewritten and not pushed.