### PR TITLE
Document RC2 ZIP hash errata without repacking

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Automated tests and the clean Windows 11 VM smoke test passed. Windows 10 remain
 
 **[Download this program](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.zip)** · [SHA-256 checksums](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.sha256) · [中文说明](#gamearchivemanager-中文)
 
+RC2 asset erratum: [`docs/RC2_ASSET_ERRATA.md`](docs/RC2_ASSET_ERRATA.md) — the original ZIP is unchanged; do not use the obsolete embedded EXE hash references.
+
 ### Privacy and RC2 security note
 
 - The application has no network, telemetry, analytics, crash-report upload, or cloud-sync logic.
@@ -133,6 +135,8 @@ Project policies: [`SECURITY.md`](SECURITY.md) · [`CONTRIBUTING.md`](CONTRIBUTI
 自动化测试和干净 Windows 11 虚拟机冒烟测试已通过；Windows 10 仍为可选未测试项。
 
 **[下载本程序](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.zip)** · [SHA-256 校验文件](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.sha256)
+
+RC2 勘误：[`docs/RC2_ASSET_ERRATA.md`](docs/RC2_ASSET_ERRATA.md)；原始 ZIP 保持不变，请勿使用其中已作废的旧 EXE 哈希引用。
 
 ### 隐私与 RC2 安全说明
 

--- a/docs/CURRENT_STATUS.md
+++ b/docs/CURRENT_STATUS.md
@@ -5,7 +5,7 @@ App version: `0.1.0`
 Build: `Release Candidate`  
 Test baseline: `py -B -m unittest discover -s tests -v` → `Ran 234 tests — OK (skipped=7)`
 Current P0: 无。`mixed_selected_and_ambiguous_content_silent_nondelivery`已完成自动与真实P0修复验证。  
-Current next action: RC2 干净 Win11 门禁证据已归并并通过；本地 `main` 当前比 `origin/main` 超前 1 个提交，完成隐私清理后可按仓库所有者授权 push。Windows 10 仍为可选未测，RC 身份不会自动变为正式 Release。
+Current next action: 所有者已决定保留原始 RC2 ZIP 并发布勘误，不重打包、不替换资产、不修改 `BUILD_TYPE`；待编排方从本分支提交 PR。Windows 10 仍为可选未测，RC 身份不会自动变为正式 Release。
 
 ## Current baseline
 

--- a/docs/GO_NO_GO_OWNER.md
+++ b/docs/GO_NO_GO_OWNER.md
@@ -8,19 +8,19 @@
 
 ## Git 与工作树
 
-- 本地 `main` 相对 `origin/main` 超前 1；该提交尚未推送。
-- 本轮新增未提交 `docs/GO_NO_GO_OWNER.md`，并在 `docs/CURRENT_STATUS.md` 增加一行 next action。
+- 本地 `main` 与 `origin/main` 对齐；本轮勘误改动尚未推送。
+- 本轮新增 `docs/RC2_ASSET_ERRATA.md`，并更新 README、状态和所有者决策记录。
 - 本轮未 push、未创建 tag、未改 VM、`BUILD_TYPE` 或发布门禁。
 
-## 发布前剩余的所有者决策
+## 已落地的所有者决定
 
-1. 将隐私清理后的本地提交通过 push 或 PR 送出；送出后才可取得新的 Windows CI / CodeQL 结果。
-2. 公开 RC2 ZIP 内嵌旧 EXE 哈希文档的处置：保留原资产并附勘误，或重新打包为新资产并发布新的 ZIP SHA-256。
-3. 是否改为正式 Release（包括修改 `BUILD_TYPE`）；这必须在上述事项完成后另行明确批准。
+1. 保留原始 RC2 ZIP，发布勘误说明；不重打包、不替换 GitHub Release 资产。
+2. 不修改 `BUILD_TYPE`，不创建 `v0.1.0` 正式 tag，不发布正式 Release。
+3. 由编排方提交包含本次勘误文档、README 链接和状态说明的 PR；本地执行者不 push。
 
 ## 默认建议
 
-**不 push、不重打包、不改 `BUILD_TYPE`**，直到仓库所有者在本轮明确授权。原始 RC2 ZIP 保持不变。
+**不重打包、不改 `BUILD_TYPE`、不打正式 tag**。原始 RC2 ZIP 保持不变；本轮交付目标是勘误文档和 PR。
 
 ## 依据与风险
 

--- a/docs/RC2_ASSET_ERRATA.md
+++ b/docs/RC2_ASSET_ERRATA.md
@@ -1,0 +1,23 @@
+# RC2 Asset Errata
+
+## English
+
+The published `v0.1.0-rc2` ZIP is intentionally unchanged. Its verified SHA-256 is:
+
+- ZIP: `BA3A9ADD4132EFF6188E3981C627400647941C572059F3D733347A3EE6823051`
+- EXE inside the ZIP: `67DF840B832EE9072375A3A267DF220DBB546FD61EF8B048EA8C8C6B17D20F71`
+
+The `RC_BUILD_NOTES.md` and `RC_SMOKE_TEST.md` files embedded in that ZIP contain older EXE hash references (`F5F2DD82…` and `9BFDE4CE…`). Those embedded references are obsolete; they do not change the verified EXE or the Windows 11 smoke-test result.
+
+This is an erratum for `0.1.0 RC2`, not a stable release. The original ZIP remains the testable asset: it is not repackaged, replaced, retagged, or re-released.
+
+## 中文
+
+已发布的 `v0.1.0-rc2` ZIP 保持不变，核验 SHA-256 如下：
+
+- ZIP：`BA3A9ADD4132EFF6188E3981C627400647941C572059F3D733347A3EE6823051`
+- ZIP 内 EXE：`67DF840B832EE9072375A3A267DF220DBB546FD61EF8B048EA8C8C6B17D20F71`
+
+该 ZIP 内嵌的 `RC_BUILD_NOTES.md` 和 `RC_SMOKE_TEST.md` 仍写有旧 EXE 哈希（`F5F2DD82…`、`9BFDE4CE…`），这些引用已作废；不影响实际 EXE 身份或 Windows 11 冒烟测试结果。
+
+本文件是 `0.1.0 RC2` 勘误，不代表正式稳定版。原始 ZIP 不重打包、不替换、不打新 tag，也不重新发布。


### PR DESCRIPTION
Owner decision: keep the published RC2 ZIP/EXE bytes. Add errata for stale in-ZIP EXE hashes. No BUILD_TYPE change, no v0.1.0 tag, no GitHub asset replacement.