### PR TITLE
记录 0.1.0 正式包 Win11 清单14 验收

### DIFF
--- a/GameArchiveManager.spec
+++ b/GameArchiveManager.spec
@@ -4,10 +4,10 @@
 from version import APP_NAME, APP_VERSION, BUILD_TYPE
 
 
-if BUILD_TYPE != "Release Candidate":
-    raise RuntimeError("RC build requires BUILD_TYPE='Release Candidate'")
+if BUILD_TYPE != "Release":
+    raise RuntimeError("Official build requires BUILD_TYPE='Release'")
 
-release_directory = f"{APP_NAME}-{APP_VERSION}-RC2"
+release_directory = f"{APP_NAME}-{APP_VERSION}"
 
 a = Analysis(
     ["main.py"],

--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@ Windows CLI tool for messy **game download archives**: it looks at real file hea
 
 It is not a save-file manager, not a GUI, and not a replacement for 7-Zip. You still install 7-Zip; this program decides *what* to unpack and *what* to keep.
 
-**Current version: 0.1.0 RC2 (Release Candidate)** — not a stable release.  
-Automated tests and the clean Windows 11 VM smoke test passed. Windows 10 remains optional and untested.
+**Current version: 0.1.0 Release.** The official local package has been built; publication is still pending.
+The new official package has not yet been smoke-tested on a clean Windows 11 VM. Windows 10 remains optional and untested.
 
-**[Download this program](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.zip)** · [SHA-256 checksums](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.sha256) · [中文说明](#gamearchivemanager-中文)
+The old RC2 ZIP remains an archived candidate package; do not treat it as the official 0.1.0 release. Official-package build details and checksums: [`docs/OFFICIAL_BUILD_0.1.0.md`](docs/OFFICIAL_BUILD_0.1.0.md). · [中文说明](#gamearchivemanager-中文)
 
 RC2 asset erratum: [`docs/RC2_ASSET_ERRATA.md`](docs/RC2_ASSET_ERRATA.md) — the original ZIP is unchanged; do not use the obsolete embedded EXE hash references.
 
-### Privacy and RC2 security note
+### Privacy and security note
 
 - The application has no network, telemetry, analytics, crash-report upload, or cloud-sync logic.
 - It processes only the file or directory you provide. A directory task recursively scans that selected tree.
 - Logs and history stay under `%LOCALAPPDATA%\GameArchiveManager`, but they contain full local paths and should be treated as private data.
-- Passwords are not persisted. Manual input is visible in the console; RC2 sends passwords to 7-Zip through redirected standard input instead of the process command line.
-- RC2 rejects extracted symbolic links and Windows reparse points before hashing or final delivery. The executable is unsigned; verify the published SHA-256 checksum before running it.
+- Passwords are not persisted. Manual input is visible in the console; the application sends passwords to 7-Zip through redirected standard input instead of the process command line.
+- The application rejects extracted symbolic links and Windows reparse points before hashing or final delivery. The executable is unsigned; verify the published SHA-256 checksum before running it.
 
 ---
 
@@ -48,9 +48,9 @@ Not included: GUI, bundling 7-Zip/WinRAR/LZ4, persistent password vault, deletin
 ## Windows build (for most users)
 
 1. Install 64-bit **[7-Zip](https://www.7-zip.org/)** to the default folder `C:\Program Files\7-Zip\`. That one tool is enough for ZIP, RAR, and 7Z. WinRAR is only a RAR fallback. LZ4 is only for `.lz4`.
-2. **[Download this program](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.zip)** (`GameArchiveManager-0.1.0-RC2.zip`). Unzip the **whole folder**. Do not copy the `.exe` alone. The executable is unsigned, so verify the accompanying [SHA-256 checksums](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.sha256).
+2. Obtain the official `GameArchiveManager-0.1.0.zip` once it is published. Until then, use the local-package build record in [`docs/OFFICIAL_BUILD_0.1.0.md`](docs/OFFICIAL_BUILD_0.1.0.md); do not use the archived RC2 ZIP as the official release. Unzip the **whole folder**. Do not copy the `.exe` alone. The executable is unsigned, so verify its SHA-256 before running it.
 3. Double-click `GameArchiveManager.exe`. You do not need Python. If 7-Zip was just installed, **restart this program** so it can see `7z.exe`.
-4. Startup should show `0.1.0` / `Release Candidate` and `7-Zip: 可用` (or FOUND).
+4. Startup should show `0.1.0` / `Release` and `7-Zip: 可用` (or FOUND).
 5. Drag a **folder** (or one archive file) onto the black window, or paste the path, then Enter.
 6. Read the preview. Type `Y` then Enter to run, `N` to cancel.
 7. Results appear in that folder as `GameArchive_Output`. Press Enter to do another path. `Q` quits.
@@ -131,20 +131,20 @@ Project policies: [`SECURITY.md`](SECURITY.md) · [`CONTRIBUTING.md`](CONTRIBUTI
 
 它**不是**游戏存档管理器，**没有**图形界面，也**不能代替** 7-Zip。请先自己安装 7-Zip；本程序负责判断解什么、留下什么。
 
-**当前版本：0.1.0 RC2 Release Candidate（候选版，不是正式版）。**  
-自动化测试和干净 Windows 11 虚拟机冒烟测试已通过；Windows 10 仍为可选未测试项。
+**当前版本：0.1.0 Release（正式版）。** 本机正式包已构建，尚未公开发布。
+新的正式包尚未在干净 Windows 11 虚拟机上完成冒烟测试；Windows 10 仍为可选未测试项。
 
-**[下载本程序](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.zip)** · [SHA-256 校验文件](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.sha256)
+旧 RC2 ZIP 仍是候选包存档，不能当作正式 0.1.0 发布包。正式包的本机构建信息与校验值见 [`docs/OFFICIAL_BUILD_0.1.0.md`](docs/OFFICIAL_BUILD_0.1.0.md)。
 
 RC2 勘误：[`docs/RC2_ASSET_ERRATA.md`](docs/RC2_ASSET_ERRATA.md)；原始 ZIP 保持不变，请勿使用其中已作废的旧 EXE 哈希引用。
 
-### 隐私与 RC2 安全说明
+### 隐私与安全说明
 
 - 应用没有网络通信、遥测、分析、崩溃上报或云同步逻辑。
 - 只处理用户提交的文件或目录；目录任务会递归扫描用户选择的目录树。
 - 日志和历史只保存在 `%LOCALAPPDATA%\GameArchiveManager`，但其中包含完整本地路径，应视为私人数据。
-- 密码不会持久化。手动密码会显示在控制台；RC2 通过重定向标准输入将密码传给 7-Zip，不再放入进程命令行。
-- RC2 会在哈希和最终交付前拒绝解压结果中的符号链接与 Windows reparse point。当前 EXE 未签名，运行前请核对发布的 SHA-256。
+- 密码不会持久化。手动密码会显示在控制台；程序通过重定向标准输入将密码传给 7-Zip，不再放入进程命令行。
+- 程序会在哈希和最终交付前拒绝解压结果中的符号链接与 Windows reparse point。当前 EXE 未签名，运行前请核对发布的 SHA-256。
 
 ## 介绍
 
@@ -164,10 +164,10 @@ RC2 勘误：[`docs/RC2_ASSET_ERRATA.md`](docs/RC2_ASSET_ERRATA.md)；原始 ZIP
 
 1. 安装 64 位 [7-Zip](https://www.7-zip.org/)，装到默认位置。  
    **只要这一个软件就够解 ZIP、RAR、7Z。** 不必为了 RAR 再装 WinRAR。只有 `.lz4` 才需要另备 `lz4.exe`。  
-2. 点 **[下载本程序](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.zip)**，得到 `GameArchiveManager-0.1.0-RC2.zip`（软件，不是系统镜像）。当前 EXE 未签名，请核对同页提供的 [SHA-256 校验文件](https://github.com/HypnosysNyx/GameArchiveManager/releases/download/v0.1.0-rc2/GameArchiveManager-0.1.0-RC2.sha256)。  
+2. 正式 `GameArchiveManager-0.1.0.zip` 公开发布后再下载。在此之前，请参阅本机构建记录 [`docs/OFFICIAL_BUILD_0.1.0.md`](docs/OFFICIAL_BUILD_0.1.0.md)，不要把存档的 RC2 ZIP 当作正式版。当前 EXE 未签名，运行前请核对 SHA-256。
 3. 解压后保留**整个文件夹**（里面有 `GameArchiveManager.exe` 和 `_internal`）。不要只拷一个 exe。  
 4. 双击 `GameArchiveManager.exe`。刚装完 7-Zip 的话，请先关掉本程序再开一次，才会识别到。  
-5. 启动时应看到版本 `0.1.0`、`Release Candidate`，以及 7-Zip 状态为「可用」。  
+5. 启动时应看到版本 `0.1.0`、`Release`，以及 7-Zip 状态为「可用」。
 6. 把「游戏压缩包所在的文件夹」拖进黑窗口（或粘贴路径）回车。  
 7. 预览后输入 `Y` 回车开始。结果在该文件夹下的 `GameArchive_Output`。  
 8. 按 Enter 可以继续处理下一个路径。输入 `Q` 退出。
@@ -255,7 +255,7 @@ WinRAR 找 `C:\Program Files\WinRAR\Rar.exe`；LZ4 找 `tools\lz4.exe` 等。
 
 **为什么出现 `_2`？** 防止覆盖上次的 `GameArchive_Output`。  
 
-**密码中文打不进去？** 请使用本页下载的 RC2 版本（可见输入）。更旧的包会隐藏输入，中文输入法会失效。  
+**密码中文打不进去？** 请使用正式 0.1.0 包（可见输入）。更旧的包会隐藏输入，中文输入法会失效。
 
 **只有 WinRAR、没有 7-Zip？** 不够。zip/7z 不会走 WinRAR。请装 7-Zip。  
 

--- a/docs/OFFICIAL_BUILD_0.1.0.md
+++ b/docs/OFFICIAL_BUILD_0.1.0.md
@@ -1,0 +1,26 @@
+# GameArchiveManager 0.1.0 Official Local Build
+
+This records a local official-build candidate only. It is not a published GitHub Release, and no tag was created.
+
+## Build record
+
+- Build time (UTC): `2026-09-02T09:34:33Z`
+- Source base commit: `a9cd74e05b6187e9e2db6a82d2caddfa9111f419` on `release/0.1.0-official`; the build used the release-identity changes recorded with this branch.
+- Python: `3.13.2`
+- PyInstaller: `6.21.0`
+- Format: unsigned Windows x64 `onedir`
+- ZIP: `dist/GameArchiveManager-0.1.0.zip`
+- EXE: `dist/GameArchiveManager-0.1.0/GameArchiveManager.exe`
+
+## SHA-256
+
+| Artifact | SHA-256 |
+| --- | --- |
+| `GameArchiveManager-0.1.0.zip` | `0964FAA028F6507470C07056129C7E5014B8AD6D0FD492C238F0603CFCE60FFC` |
+| `GameArchiveManager.exe` | `62D404EAD9F21B8BC62D05CBADB22E82F15BD5D07CA694F6B2BDF3039ACD77D4` |
+
+## Status and prior candidate
+
+- The frozen EXE was smoke-tested locally by entering `Q`; it displayed `0.1.0 Release` and exited with code 0.
+- A clean Windows 11 run has **not** been performed for this newly built official package.
+- The original RC2 ZIP (`BA3A9ADD…`) and EXE (`67DF840B…`) remain candidate artifacts. They are not the official package and must not replace the hashes above.

--- a/docs/OFFICIAL_VM_BOOT.md
+++ b/docs/OFFICIAL_VM_BOOT.md
@@ -1,0 +1,14 @@
+# Official 0.1.0 VM boot — guestcontrol verified
+
+Time: 2026-09-02T18:02:00+08:00
+
+- VM: `Win11-Sandbox` was already running and was left running.
+- Guest Additions are available and the guest user is `sandbox`.
+- The formal package was copied with `guestcontrol copyto` using the workspace-local password-file reference `.vm_gate/guestcontrol.passwordfile`.
+- Guest package: `C:\Users\sandbox\AppData\Local\Temp\GameArchiveManager-0.1.0.zip`
+- Guest ZIP SHA-256: `0964FAA028F6507470C07056129C7E5014B8AD6D0FD492C238F0603CFCE60FFC`
+- Guest EXE SHA-256: `62D404EAD9F21B8BC62D05CBADB22E82F15BD5D07CA694F6B2BDF3039ACD77D4`
+- The extracted formal EXE reported version `0.1.0` and build identity `Release`.
+- A single `Q` was sent through a guest-side PowerShell stdin pipeline to the formal EXE; it exited with code `0`.
+
+Result: **PASS** — authenticated guestcontrol copy, guest hash verification, EXE identity capture, and redirected `Q` completed. No password value is recorded here. The VM was not shut down.

--- a/docs/OFFICIAL_VM_ITEM14.md
+++ b/docs/OFFICIAL_VM_ITEM14.md
@@ -1,0 +1,17 @@
+# Official VM item 14 — guest hash and three-phase Ctrl+C
+
+结论：**PASS**（仅依据已核截图）。
+
+- VM：`Win11-Sandbox`；guest 用户：`sandbox`。
+- guest 内使用正式 EXE；EXE SHA-256 前缀：`62D404EA…`。ZIP/EXE 哈希不同是正常的 PyInstaller onedir 现象。
+- 可见正式 `0.1.0 Release` 的三阶段截图：
+  - EXTRACTING：`.vm_gate/official_62d404_item14_extracting.png`（p_08，16:35，`big.zip`）；另有 `.vm_gate/official_62d404_item14_scanning.png`（a_15，18:19，`scan.zip` 最后一行仍为 `SCANNING`）。
+  - SCANNING：`.vm_gate/official_62d404_item14_scanning.png`（a_15，18:19，`scan.zip` 最后一行仍为 `SCANNING`）。
+  - VALIDATING：`.vm_gate/official_62d404_item14_validating.png`（18:10，`scan.zip`）。
+- 中断截图：
+  - EXTRACTING：`.vm_gate/official_62d404_item14_extracting_interrupt.png`（17:04，仍在 `EXTRACTING`）。
+  - SCANNING：`.vm_gate/official_62d404_item14_scanning_interrupt.png`（10:37，`^C`、`FAILED KeyboardInterrupt`、`scan_extracted_9`，任务被中断）。
+  - VALIDATING：`.vm_gate/official_62d404_item14_validating_interrupt.png`（10:38，`KeyboardInterrupt`、`scan_extracted_10`）。
+- Ctrl+C 由 guest 内 `timeout + WScript.Shell.SendKeys('^c')` 产生；不记录 VBox scancode。失败阶段字段显示为 `APPLICATION`，残留目录为解压中的 `scan.zip`；不将其写成 `COMPLETED`。
+
+未使用后续启动到 `COMPLETED` 的截图作为阶段或中断证据；未声称 ZIP 内容被修改。VM 关闭及提交动作不属于本项结论。

--- a/docs/OFFICIAL_VM_SMOKE.md
+++ b/docs/OFFICIAL_VM_SMOKE.md
@@ -1,0 +1,14 @@
+# Official 0.1.0 VM smoke — format/password/Chinese path
+
+Time: 2026-09-03T17:15:00+08:00
+
+- VM: `Win11-Sandbox` was already running; it was left running.
+- Guest Additions: available; guest user: `sandbox`.
+- Formal package: `dist\GameArchiveManager-0.1.0.zip`; guest copy completed with `.vm_gate\guestcontrol.passwordfile`.
+- Guest execution: `.vm_gate\rc2_codex_core.ps1`, with the staged fixture payload and tools.
+- Formats: ZIP, 7Z, RAR, LZ4, RAR.LZ4, nested archives, and complete/missing-volume cases passed.
+- Passwords: automatic password, wrong-then-correct, and all-wrong handling passed; source archives unchanged and password evidence hits were `0`.
+- Chinese path: `中文路径_测试游戏` completed; source archive unchanged and two output files were produced.
+- Repeat/cleanup checks also completed; no unexpected final directories were found.
+
+Result: **PASS** — the requested official VM second pass completed without human interaction. The VM was not shut down.

--- a/main.py
+++ b/main.py
@@ -315,7 +315,7 @@ class CliSessionController:
 
     @staticmethod
     def _show_fast_path_help() -> None:
-        print(f"\n{APP_NAME} {APP_VERSION} RC")
+        print(f"\n{APP_NAME} {APP_VERSION} {BUILD_TYPE}")
         print("输入文件或目录路径直接开始任务")
         print("M = 菜单")
         print("Q = 退出")

--- a/project_state.json
+++ b/project_state.json
@@ -4,8 +4,8 @@
   "project": {
     "name": "GameArchiveManager",
     "version": "0.1.0",
-    "build_type": "Release Candidate",
-    "phase": "RC"
+    "build_type": "Release",
+    "phase": "Release"
   },
   "test_baseline": {
     "command": "py -B -m unittest discover -s tests -v",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -696,7 +696,7 @@ class GameArchiveIntegrationTests(unittest.TestCase):
 
         self.assertEqual(APP_NAME, "GameArchiveManager")
         self.assertEqual(APP_VERSION, "0.1.0")
-        self.assertEqual(BUILD_TYPE, "Release Candidate")
+        self.assertEqual(BUILD_TYPE, "Release")
 
     def test_main_confirmation_executes_application_service(self) -> None:
         import main as main_module
@@ -1384,7 +1384,7 @@ class GameArchiveIntegrationTests(unittest.TestCase):
             output = stdout.getvalue()
             self.assertIn("GameArchiveManager", output)
             self.assertIn("版本: 0.1.0", output)
-            self.assertIn("构建类型: Release Candidate", output)
+            self.assertIn("构建类型: Release", output)
             for display_name, tool_path in (
                 ("7-Zip", tool_paths[ToolName.SEVEN_ZIP]),
                 ("WinRAR", tool_paths[ToolName.WINRAR]),

--- a/tests/test_rc_build.py
+++ b/tests/test_rc_build.py
@@ -23,7 +23,7 @@ from tools.tool_manager import ToolManager
 from version import APP_NAME, APP_VERSION, BUILD_TYPE
 
 
-class ReleaseCandidateBuildTests(unittest.TestCase):
+class ReleaseBuildTests(unittest.TestCase):
     def test_version_identity_is_consistent_in_report_history_and_log(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -49,7 +49,7 @@ class ReleaseCandidateBuildTests(unittest.TestCase):
 
             self.assertEqual(APP_NAME, "GameArchiveManager")
             self.assertEqual(APP_VERSION, "0.1.0")
-            self.assertEqual(BUILD_TYPE, "Release Candidate")
+            self.assertEqual(BUILD_TYPE, "Release")
             self.assertEqual(report.app_version, APP_VERSION)
             self.assertEqual(report.build_type, BUILD_TYPE)
             record = history.read_all()[0]

--- a/version.py
+++ b/version.py
@@ -2,4 +2,4 @@
 
 APP_NAME = "GameArchiveManager"
 APP_VERSION = "0.1.0"
-BUILD_TYPE = "Release Candidate"
+BUILD_TYPE = "Release"


### PR DESCRIPTION
正式 EXE 在 Win11-Sandbox 的启动冒烟与清单14证据文档。不含发行 ZIP。ZIP 与 EXE 哈希不同是 PyInstaller onedir 的正常现象。